### PR TITLE
Deactivate flatpak role

### DIFF
--- a/devstation/ansible/playbook.yaml
+++ b/devstation/ansible/playbook.yaml
@@ -5,8 +5,8 @@
         name: packages
     - import_role:
         name: mitmproxy
-    - import_role:
-        name: flatpak
+    # - import_role:
+    #     name: flatpak
     - import_role:
         name: gnome
     - import_role:


### PR DESCRIPTION
Does not work as expected when the image is used in a `packer` based workflow. Flatpak configurations get overriden by the installation process. Removed for now.