### PR TITLE
Replace base image with upstream Silverblue

### DIFF
--- a/devstation/Containerfile
+++ b/devstation/Containerfile
@@ -1,52 +1,7 @@
-## 1. BUILD ARGS
-# These allow changing the produced image by passing different build args to adjust
-# the source from which your image is built.
-# Build args can be provided on the commandline when building locally with:
-#   podman build -f Containerfile --build-arg FEDORA_VERSION=40 -t local-image
-
-# SOURCE_IMAGE arg can be anything from ublue upstream which matches your desired version:
-# See list here: https://github.com/orgs/ublue-os/packages?repo_name=main
-# - "silverblue"
-# - "kinoite"
-# - "sericea"
-# - "onyx"
-# - "lazurite"
-# - "vauxite"
-# - "base"
-#
-#  "aurora", "bazzite", "bluefin" or "ucore" may also be used but have different suffixes.
-ARG SOURCE_IMAGE="silverblue"
-
-## SOURCE_SUFFIX arg should include a hyphen and the appropriate suffix name
-# These examples all work for silverblue/kinoite/sericea/onyx/lazurite/vauxite/base
-# - "-main"
-# - "-nvidia"
-# - "-asus"
-# - "-asus-nvidia"
-# - "-surface"
-# - "-surface-nvidia"
-#
-# aurora, bazzite and bluefin each have unique suffixes. Please check the specific image.
-# ucore has the following possible suffixes
-# - stable
-# - stable-nvidia
-# - stable-zfs
-# - stable-nvidia-zfs
-# - (and the above with testing rather than stable)
-ARG SOURCE_SUFFIX="-main"
-
-## SOURCE_TAG arg must be a version built for the specific image: eg, 39, 40, gts, latest
+# SOURCE_TAG is the image version used (e.g. 41).
 ARG SOURCE_TAG="latest"
-
-
-### 2. SOURCE IMAGE
-## this is a standard Containerfile FROM using the build ARGs above to select the right upstream image
-FROM ghcr.io/ublue-os/${SOURCE_IMAGE}${SOURCE_SUFFIX}:${SOURCE_TAG}
-
-
-### 3. MODIFICATIONS
-## make modifications desired in your image and install packages by modifying the build.sh script
-## the following RUN directive does all the things required to run "build.sh" as recommended.
+FROM quay.io/fedora-ostree-desktops/silverblue:${SOURCE_TAG}
+# FROM quay.io/fedora/fedora-silverblue:${SOURCE_TAG}
 
 COPY . /tmp/build/
 

--- a/devstation/ansible/playbook.yaml
+++ b/devstation/ansible/playbook.yaml
@@ -13,3 +13,5 @@
         name: sudo
     - import_role:
         name: doh
+    - import_role:
+        name: system-update

--- a/devstation/ansible/roles/system-update/files/usr/etc/rpm-ostreed.conf
+++ b/devstation/ansible/roles/system-update/files/usr/etc/rpm-ostreed.conf
@@ -1,0 +1,9 @@
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# For option meanings, see rpm-ostreed.conf(5).
+
+[Daemon]
+AutomaticUpdatePolicy=stage
+#IdleExitTimeout=60
+#LockLayering=false
+#Recommends=true

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/system-preset/10-flatpak-system-update.preset
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/system-preset/10-flatpak-system-update.preset
@@ -1,0 +1,1 @@
+enable flatpak-update-system.service

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/system/flatpak-update-system.service
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/system/flatpak-update-system.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Flatpak Automatic Update
+Documentation=man:flatpak(1)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
+ExecStart=/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive ; /usr/bin/flatpak --system repair

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/system/flatpak-update-system.timer
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/system/flatpak-update-system.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Flatpak Automatic Update Trigger
+Documentation=man:flatpak(1)
+
+[Timer]
+RandomizedDelaySec=10m
+OnBootSec=2m
+OnCalendar=*-*-* 4:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/user-preset/10-flatpak-user-update.preset
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/user-preset/10-flatpak-user-update.preset
@@ -1,0 +1,1 @@
+enable flatpak-update-user.service

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/user/flatpak-update-user.service
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/user/flatpak-update-user.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Flatpak Automatic Update
+Documentation=man:flatpak(1)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
+ExecStart=/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive ; /usr/bin/flatpak --user repair

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/user/flatpak-update-user.timer
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/user/flatpak-update-user.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Flatpak Automatic Update Trigger
+Documentation=man:flatpak(1)
+
+[Timer]
+RandomizedDelaySec=10m
+OnBootSec=2m
+OnCalendar=*-*-* 4:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/devstation/ansible/roles/system-update/tasks/main.yaml
+++ b/devstation/ansible/roles/system-update/tasks/main.yaml
@@ -1,0 +1,5 @@
+- name: Copy /usr content
+  become: true
+  ansible.builtin.copy:
+    src: usr/
+    dest: /usr/


### PR DESCRIPTION
Reason to switch is, that the intended image use case does not care about most modifications of the `ublue-main` image. Instead, some things need to be disabled as they cause problems in the intended environment.

New base image:
  - https://gitlab.com/fedora/ostree/ci-test
  - https://quay.io/organization/fedora-ostree-desktops

Image used by the `ublue` project as well:
https://github.com/ublue-os/main/blob/3eae314e16c1516b3e550006bb7517d34bdc49e5/Containerfile

It might be possible to switch to https://quay.io/repository/fedora/fedora-silverblue at some point, but seems currently not recommended.

Add new Ansible role for configuration of system updates via `rpm-ostreed` and `flatpak`, which is missing in the new base image.