### PR TITLE
Refactor default systemd units

### DIFF
--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/system-preset/10-update.preset
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/system-preset/10-update.preset
@@ -1,2 +1,0 @@
-enable rpm-ostreed-automatic.timer
-enable flatpak-update-system.timer

--- a/devstation/ansible/roles/system-update/files/usr/lib/systemd/user-preset/10-update.preset
+++ b/devstation/ansible/roles/system-update/files/usr/lib/systemd/user-preset/10-update.preset
@@ -1,1 +1,0 @@
-enable flatpak-update-user.timer

--- a/devstation/ansible/roles/system-update/tasks/main.yaml
+++ b/devstation/ansible/roles/system-update/tasks/main.yaml
@@ -3,3 +3,31 @@
   ansible.builtin.copy:
     src: usr/
     dest: /usr/
+
+- name: Ensure systemd directories
+  become: yes
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - /usr/lib/systemd/system/timers.target.wants
+    - /usr/lib/systemd/user/timers.target.wants
+
+- name: Enable default system systemd timers
+  become: true
+  ansible.builtin.file:
+    path: /usr/lib/systemd/system/timers.target.wants/{{ item }}
+    src: ../{{ item }}
+    state: link
+  loop:
+    - rpm-ostreed-automatic.timer
+    - flatpak-update-system.timer
+
+- name: Enable default user systemd timers
+  become: true
+  ansible.builtin.file:
+    path: /usr/lib/systemd/user/timers.target.wants/{{ item }}
+    src: ../{{ item }}
+    state: link
+  loop:
+    - flatpak-update-user.timer


### PR DESCRIPTION
Remove presets. They are not working with the target deployment method
of either using Anaconda or a `rebase`. Replaced with regular symbolic
links.