### PR TITLE
Fix Containerfile default source tag

### DIFF
--- a/devstation/Containerfile
+++ b/devstation/Containerfile
@@ -1,5 +1,5 @@
 # SOURCE_TAG is the image version used (e.g. 41).
-ARG SOURCE_TAG="latest"
+ARG SOURCE_TAG="41"
 FROM quay.io/fedora-ostree-desktops/silverblue:${SOURCE_TAG}
 # FROM quay.io/fedora/fedora-silverblue:${SOURCE_TAG}
 


### PR DESCRIPTION
`latest` is not a valid tag for the current base image.