### PR TITLE
Replace `mitmproxy` with `squid` config

### DIFF
--- a/devstation/ansible/playbook.yaml
+++ b/devstation/ansible/playbook.yaml
@@ -4,9 +4,7 @@
     - import_role:
         name: packages
     - import_role:
-        name: mitmproxy
-    # - import_role:
-    #     name: flatpak
+        name: squid
     - import_role:
         name: gnome
     - import_role:

--- a/devstation/ansible/roles/doh/files/usr/share/containers/systemd/dnscrypt-proxy.container
+++ b/devstation/ansible/roles/doh/files/usr/share/containers/systemd/dnscrypt-proxy.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Container running dnscrypt-proxy
-Requires=mitmproxy.service
-After=mitmproxy.service
+Requires=squid.service
+After=squid.service
 
 [Container]
 Image=ghcr.io/klutchell/dnscrypt-proxy:2.1.5

--- a/devstation/ansible/roles/squid/files/etc/squid/direct.conf
+++ b/devstation/ansible/roles/squid/files/etc/squid/direct.conf
@@ -1,0 +1,8 @@
+http_access allow all
+http_port 3128
+
+# Deactivate caching.
+cache deny all
+
+# Optimize restart time.
+shutdown_lifetime 1 second

--- a/devstation/ansible/roles/squid/files/etc/squid/proxy.conf
+++ b/devstation/ansible/roles/squid/files/etc/squid/proxy.conf
@@ -1,0 +1,19 @@
+http_access allow all
+http_port 3128
+
+# Upstream proxy.
+cache_peer 10.0.2.2 parent 9000 0 no-query no-digest default name=base
+
+# Forward domains directly.
+acl forwarding dstdomain "/etc/squid/forwarding.txt"
+
+always_direct allow forwarding
+# Force all other requests to go through the upstream peer.
+# Necessary to allow "https://..."
+never_direct allow all
+
+# Deactivate caching.
+cache deny all
+
+# Optimize restart time.
+shutdown_lifetime 1 second

--- a/devstation/ansible/roles/squid/files/usr/lib/squid/disable
+++ b/devstation/ansible/roles/squid/files/usr/lib/squid/disable
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+config_dir=/etc/systemd/system.conf.d
+
+rm -f $config_dir/00-proxy.conf
+
+# Reload systemd configuration.
+systemctl daemon-reexec

--- a/devstation/ansible/roles/squid/files/usr/lib/squid/enable
+++ b/devstation/ansible/roles/squid/files/usr/lib/squid/enable
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+share_files=/usr/share/squid
+config_dir=/etc/systemd/system.conf.d
+
+mkdir -p $config_dir
+cp -f $share_files/systemd/system.conf.d/00-proxy.conf $config_dir/
+
+# Reload systemd configuration.
+systemctl daemon-reexec

--- a/devstation/ansible/roles/squid/files/usr/share/containers/systemd/squid.container
+++ b/devstation/ansible/roles/squid/files/usr/share/containers/systemd/squid.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=Container running Squid
+
+[Container]
+Image=ghcr.io/mpreu/squid:5.9
+PublishPort=3128:3128
+Volume=/etc/squid:/etc/squid
+Network=podman
+
+[Service]
+Restart=always
+# Extend timeout for image pulling.
+TimeoutStartSec=120
+ExecStartPost=/usr/lib/squid/enable
+ExecStopPost=/usr/lib/squid/disable
+
+[Install]
+# Start by default on boot.
+WantedBy=multi-user.target default.target

--- a/devstation/ansible/roles/squid/files/usr/share/squid/systemd/system.conf.d/00-proxy.conf
+++ b/devstation/ansible/roles/squid/files/usr/share/squid/systemd/system.conf.d/00-proxy.conf
@@ -1,0 +1,4 @@
+[Manager]
+DefaultEnvironment="http_proxy=10.88.0.1:3128"
+DefaultEnvironment="https_proxy=10.88.0.1:3128"
+DefaultEnvironment="no_proxy=localhost,127.0.0.0/8,::1"

--- a/devstation/ansible/roles/squid/tasks/main.yaml
+++ b/devstation/ansible/roles/squid/tasks/main.yaml
@@ -1,0 +1,26 @@
+- name: Copy /usr content
+  become: true
+  ansible.builtin.copy:
+    src: usr/
+    dest: /usr/
+
+- name: Copy config files
+  become: true
+  ansible.builtin.copy:
+    src: etc/
+    dest: /etc/
+
+- name: Add executable permissions to scripts
+  file:
+    dest: "{{ item }}"
+    mode: a+x
+  loop:
+    - /usr/lib/squid/enable
+    - /usr/lib/squid/disable
+
+- name: Symlink config file
+  become: true
+  file:
+    path: /etc/squid/squid.conf
+    src: /etc/squid/direct.conf
+    state: link


### PR DESCRIPTION
`mitmproxy` is not able to define direct forwarding without hitting upstream proxies, making it unusable for the required use-case.