### PR TITLE
Remove keepalive workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,13 +92,3 @@ jobs:
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-
-  keepalive:
-    name: Keepalive Workflow
-    if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
Repository for `gautamkrishnar/keepalive-workflow` is deactivated due to it being a TOS violation. Remove for now to prevent failing pipelines.